### PR TITLE
Modified fn_lutablegen.R (looong time ago, need to verify) and added …

### DIFF
--- a/R/fn_lutablegen.R
+++ b/R/fn_lutablegen.R
@@ -1,8 +1,11 @@
 library('sqldf')
 
-lutablegen <- function(land.segment, basepath, lu.scenario) {
+lutablegen <- function(land.segment, basepath, lu.scenario, ccextra = FALSE) {
   # INPUTS ----------
   lufile.list <- list.files(paste0(basepath, '/input/scenario/river/land_use/'),pattern=lu.scenario)
+  if (!is.logical(ccextra)) {
+    lufile.list <- rbind(lufile.list, ccextra)
+  }
   lutable_yrs = FALSE
   for (i in 1:length(lufile.list)) {
     lufile <- lufile.list[i]

--- a/code/Working_Gage_Vs_Vahydro_Dashboard_2019.Rmd
+++ b/code/Working_Gage_Vs_Vahydro_Dashboard_2019.Rmd
@@ -45,8 +45,18 @@ library(tinytex)
 options(tinytex.verbose = TRUE)
 
 # # INPUTS
+# Set defaults for river segment and run ID
 riv.seg <- 'RU5_6030_0001'
 run.id <- '120'
+# Use command line args for riverseg and runid if supplied, i.e., this script is run as:
+# Rscript Working_Gage_Vs_Dashboard_2019.Rmd RU5_6030_0001 121
+if (length(argst) >= 1) {
+  riv.seg=argst[1]
+}
+if (length(argst) >= 2) {
+  run.id=argst[2]
+}
+
 mod.phase1 <- 'p6/p6_gb604' #or "p532c-sova" (phase 5)
 mod.scenario1 <- 'CFBASE30Y20180615' #or "p532cal_062211" (phase 5)
 mod.phase2 <- 'p6/p6_gb604' #or "p532c-sova" (phase 5)


### PR DESCRIPTION
…arg support for dashboards

Verified changes in fn_lutablegen.R, added preliminary support for an extra argument to lutablegen() ccextra, which allows the user to add an extra file into the list of land use files to parse.  This is just a preliminary fix, it may not actually work since I don't see that the scripts I used to call lutablegen() have that added (they were not modified in this commit anyway).  In addition to adding a file, the user might need to specify the year to use for that added file since the files naming convention may differ from that used to determine the year from other files.  Actually, this is probably a bunk fix either way...