### PR TITLE
Added scenario labeling in fig1.hydrograph

### DIFF
--- a/R/Examples/quick_compare.R
+++ b/R/Examples/quick_compare.R
@@ -18,8 +18,8 @@ run.id1 <- 120
 run.id2 <- 121
 gage_number <- '01671020'
 
-data1 <- vahydro_import_data_cfs(riv.seg, run.id1, token, site, start.date, end.date)
-data2 <- gage_import_data_cfs(gage_number, start.date, end.date)
+data2 <- vahydro_import_data_cfs(riv.seg, run.id1, token, site, start.date, end.date)
+data1 <- gage_import_data_cfs(gage_number, start.date, end.date)
 
 # TRIMMING DATA TO PROPER WATER YEAR
 data1 <- water_year_trim(data1)
@@ -27,7 +27,7 @@ data2 <- water_year_trim(data2)
 
 all_data <- all_data_maker(data1, data2)
 
-fig1.hydrograph(all_data)
+fig1.hydrograph(all_data, 'USGS', "VAHydro")
 #include_graphics("fig1.png")
 pp <- readPNG("fig1.png")
 plot.new() 
@@ -38,6 +38,7 @@ metrics2 <- metrics_calc_all(data2)
 percent_difference <- metrics_compare(metrics1, metrics2, riv.seg)
 
 Table1 <- tab1.monthly.low.flows(percent_difference)
+Table2 <- tab2.monthly.average.flows(percent_difference)
 
 
 #https://github.com/HARPgroup/cbp6/blob/master/code/automated_metric_2_vahydro.R

--- a/R/fig1.hydrograph.R
+++ b/R/fig1.hydrograph.R
@@ -1,4 +1,4 @@
-fig1.hydrograph <- function(all_data) {
+fig1.hydrograph <- function(all_data, cn1='Scenario1', cn2='Scenario2') {
   # SETTING UP PLOTS
   # Basic hydrograph -----
   # Max/min for y axis scaling
@@ -35,11 +35,12 @@ fig1.hydrograph <- function(all_data) {
     fixtheyscale<- scale_y_continuous(trans = log_trans(), breaks = base_breaks(), 
                                       labels=scaleFUN, limits=c(min,max))
   df <- data.frame(as.Date(all_data$Date), all_data$`Scenario 1 Flow`, all_data$`Scenario 2 Flow`); 
+  #colnames(df) <- c('Date', cn1, cn2)
   colnames(df) <- c('Date', 'Scenario1', 'Scenario2')
   options(scipen=5, width = 1400, height = 950)
   myplot <- ggplot(df, aes(x=Date)) + 
-    geom_line(aes(y=Scenario1, color="VAHydro Scen. 1"), size=0.5) +
-    geom_line(aes(y=Scenario2, color="VAHydro Scen. 2"), size=0.5)+
+    geom_line(aes(y=Scenario1, color=cn1), size=0.5) +
+    geom_line(aes(y=Scenario2, color=cn2), size=0.5)+
     fixtheyscale+
     theme_bw()+ 
     theme(legend.position="top", 


### PR DESCRIPTION
Daniel - please review this pull request.  I added the ability to customize the labels in fig1.hydrograph routine as a trial to be used in all others.  I am not super familiar with ggplot so I was a little unsure of how the label appeared (to my eye) to be passed in with the attribute "color" in the aes() command.  BUt it works, or seems to. Please let me know if this seems sound and I will push it into some other graphics and tables.  I would like to have a quick visual cue as to what we are seeing in each table so that they stand alone as opposed to needing to review a preamble that tells you "scenario 1 is USGS and scenario 2 is the vahydro model" or something.

I changed: ```geom_line(aes(y=Scenario2, color="VAHydro Scen. 1")```
To: ```aes(y=Scenario1, color=cn1)```

Where I passed in cn1 (and cn2) to the function with defaults already set:  ```fig1.hydrograph <- function(all_data, cn1='Scenario1', cn2='Scenario2') {```
