### PR TITLE
Query or property by name before saving, without varkey or propcode a…

### DIFF
--- a/R/vahydro_post_metric_to_scenprop.R
+++ b/R/vahydro_post_metric_to_scenprop.R
@@ -1,9 +1,8 @@
 vahydro_post_metric_to_scenprop <- function(scenprop.pid, met.varkey, met.propcode, met.name, met.value, site, token) {
   hydroid = scenprop.pid
-
+  
   metinfo <- list(
-    varkey = met.varkey,
-    propcode = met.propcode,
+    propname = met.name,
     featureid = as.integer(hydroid),
     entity_type = "dh_properties"
   )


### PR DESCRIPTION
…s inputs, so as not to create multiple copies

Under a few cases, vahydro_post_metric_to_scenprop() will create 2 properties with the same name (like there are only 12 in the db right now, but there could be more eventually).  
1. This should never be the case, as properties should be unique by name.
2. The problem is the the call to getProperty includes varkey, and propcode, but NOT propname.  This should be the other way around, only propname should be used in the check for existing properties. 
3. Then, if this is an UPDATE and there is some change for the varkey, this can be set later prior to the PostProperty().  
3. Never ever should "propcode" be given for the uniqueness check, when creating a new feature, since that too is irrelevant, as propname should  be the only thing used in these routines since they are setting model scenario data.  

I wanted to ping @jdkleiner and @hdaniel7 to get you guys to review this, and ideally test it if you have a spare moment.  I am not sure if it works... I mean, it saves the properties, and I haven't gotten a duplicate but... I just wanted to get the code up there.