### PR TITLE
explore relationship between temp, precip and et

### DIFF
--- a/analysis/rwb_cc_et_f_t.R
+++ b/analysis/rwb_cc_et_f_t.R
@@ -77,6 +77,7 @@ decall <- sqldf(
 decall
 plot(decall$dec_dpre ~ decall$dec_dtmp)
 plot(decall$evap ~ decall$dtmp)
+plot(dec10$evap ~ dec10$dtmp)
 plot(decall$dpre ~ decall$dtmp)
 plot(pct.changes.10$evap.mean ~ pct.changes.10$prcp.mean, ylim = c(0,20), xlim = c(-10, 30))
 points(pct.changes.50$evap.mean ~ pct.changes.50$prcp.mean, col = 'red')

--- a/analysis/rwb_cc_et_f_t.R
+++ b/analysis/rwb_cc_et_f_t.R
@@ -1,0 +1,85 @@
+precp_ens_10_pct <- PRCP.ENS.10.PCT
+temp_ens_10_pct <- TEMP.ENS.10.PCT
+pct_changes_10 <- pct.changes.10
+pct_names <- names(pct_changes_10)
+pct_names[2] <- 'evap_mean'
+names(pct_changes_10) <- pct_names
+# medians
+precp_ens_50_pct <- PRCP.ENS.50.PCT
+temp_ens_50_pct <- TEMP.ENS.50.PCT
+pct_changes_50 <- pct.changes.50
+names(pct_changes_50) <- pct_names
+# 90s
+precp_ens_90_pct <- PRCP.ENS.90.PCT
+temp_ens_90_pct <- TEMP.ENS.90.PCT
+pct_changes_90 <- pct.changes.90
+names(pct_changes_90) <- pct_names
+
+dec10 <- sqldf(
+  ' select a.FIPS, a.Dec as dec_dpre, b.Dec as dec_dtmp, 
+      a.Total as dtmp, b.Total as dpre, c.evap_mean as evap
+    from precp_ens_10_pct as a
+    left outer join temp_ens_10_pct as b 
+    on (
+     a.FIPS = b.FIPS
+    )
+    left outer join pct_changes_10 as c
+    on (
+     a.FIPS = substr(c.segment,2,5)
+    )
+  '
+  )
+plot(dec10$dec_dpre ~ dec10$dec_dtmp)
+
+dec50 <- sqldf(
+  ' select a.FIPS, a.Dec as dec_dpre, b.Dec as dec_dtmp, 
+      a.Total as dtmp, b.Total as dpre, c.evap_mean as evap
+    from precp_ens_50_pct as a
+    left outer join temp_ens_50_pct as b 
+    on (
+     a.FIPS = b.FIPS
+    )
+    left outer join pct_changes_50 as c
+    on (
+     a.FIPS = substr(c.segment,2,5)
+    )
+  '
+)
+plot(dec50$dec_dpre ~ dec50$dec_dtmp)
+
+dec90 <- sqldf(
+  ' select a.FIPS, a.Dec as dec_dpre, b.Dec as dec_dtmp, 
+      a.Total as dtmp, b.Total as dpre, c.evap_mean as evap
+    from precp_ens_90_pct as a
+    left outer join temp_ens_90_pct as b 
+    on (
+     a.FIPS = b.FIPS
+    )
+    left outer join pct_changes_90 as c
+    on (
+     a.FIPS = substr(c.segment,2,5)
+    )
+  '
+)
+plot(dec90$dec_dpre ~ dec90$dec_dtmp)
+
+decall <- sqldf(
+  " select * from dec10 where FIPS like '51%'
+    UNION
+    select * from dec50 where FIPS like '51%'
+    UNION
+    select * from dec90 where FIPS like '51%'
+  "
+)
+decall
+plot(decall$dec_dpre ~ decall$dec_dtmp)
+plot(decall$evap ~ decall$dtmp)
+plot(decall$dpre ~ decall$dtmp)
+# include pcrp.evap.landuse.table.R
+plot(pct.changes.10$evap.mean ~ pct.changes.10$prcp.mean, ylim = c(0,20), xlim = c(-10, 30))
+points(pct.changes.50$evap.mean ~ pct.changes.50$prcp.mean, col = 'red')
+points(pct.changes.90$evap.mean ~ pct.changes.90$prcp.mean, col = 'blue')
+# Forest
+plot(pct.changes.10$evap.mean ~ pct.changes.10$prcp.mean, ylim = c(0,20), xlim = c(-10, 30))
+points(pct.changes.50$evap.mean ~ pct.changes.50$prcp.mean, col = 'red')
+points(pct.changes.90$evap.mean ~ pct.changes.90$prcp.mean, col = 'blue')

--- a/analysis/rwb_cc_et_f_t.R
+++ b/analysis/rwb_cc_et_f_t.R
@@ -1,3 +1,6 @@
+# TO run this first
+# you must include pcrp.evap.landuse.table.R
+
 precp_ens_10_pct <- PRCP.ENS.10.PCT
 temp_ens_10_pct <- TEMP.ENS.10.PCT
 pct_changes_10 <- pct.changes.10
@@ -75,7 +78,6 @@ decall
 plot(decall$dec_dpre ~ decall$dec_dtmp)
 plot(decall$evap ~ decall$dtmp)
 plot(decall$dpre ~ decall$dtmp)
-# include pcrp.evap.landuse.table.R
 plot(pct.changes.10$evap.mean ~ pct.changes.10$prcp.mean, ylim = c(0,20), xlim = c(-10, 30))
 points(pct.changes.50$evap.mean ~ pct.changes.50$prcp.mean, col = 'red')
 points(pct.changes.90$evap.mean ~ pct.changes.90$prcp.mean, col = 'blue')


### PR DESCRIPTION
Added file leveraged Daniels scripts to do some follow up exploration of the role of temperature changes and its effect on precip and ET.  A curious finding was that in the 10/10 scenario there were temperature decreases in a small number of segments, and those segments *still* had an increase in ET.  This may have been due to the change in evapotranspiration equation used in the CC scenarios because the standard cbp6 method did not perform well under increasing temperatures. All scenarios showed a "topping out" where both precip and evap increases plateaued after about a 13% increase in Temp.